### PR TITLE
Avoid transitive cast in DirectoryPath abstract

### DIFF
--- a/src/locator/DirectoryPath.hx
+++ b/src/locator/DirectoryPath.hx
@@ -179,7 +179,7 @@ abstract DirectoryPath(PathString) to String {
 		var nextRelPath = relativeCurrent(relPath, dos);
 
 		if (nextRelPath.isSome())
-			return DirectoryPath.from(refDirPath + nextRelPath.unwrap());
+			return PathString.from(refDirPath + nextRelPath.unwrap()).addTrailingDelimiter();
 
 		nextRelPath = relativeParent(relPath, dos);
 		while (nextRelPath.isSome()) {


### PR DESCRIPTION
This line previously required a cast from a DirectoryPath, to a String, to a PathString. This is a transitive cast, and as of haxe 4.2 these are now disabled by default (see https://github.com/HaxeFoundation/haxe/pull/9698) and therefore this line causes a compiler error. This change avoids the transitive cast by directly returning a PathString.

Partially addresses: https://github.com/fal-works/hlc-compiler/issues/1